### PR TITLE
Update to use SparkCatalogConfig in SparkCatalogTestBase

### DIFF
--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
@@ -23,21 +23,15 @@ import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 
 public enum SparkCatalogConfig {
-  SPARK_CATALOG_HIVE("testhive", SparkCatalog.class.getName(), ImmutableMap.of(
+  HIVE("testhive", SparkCatalog.class.getName(), ImmutableMap.of(
       "type", "hive",
       "default-namespace", "default"
   )),
-  SPARK_CATALOG_HADOOP("testhadoop", SparkCatalog.class.getName(), ImmutableMap.of(
+  HADOOP("testhadoop", SparkCatalog.class.getName(), ImmutableMap.of(
       "type", "hadoop"
   )),
-  SPARK_SESSION_CATALOG_HIVE("spark_catalog", SparkSessionCatalog.class.getName(), ImmutableMap.of(
+  SPARK("spark_catalog", SparkSessionCatalog.class.getName(), ImmutableMap.of(
       "type", "hive",
-      "default-namespace", "default",
-      "parquet-enabled", "true",
-      "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
-  )),
-  SPARK_SESSION_CATALOG_HADOOP("spark_catalog", SparkSessionCatalog.class.getName(), ImmutableMap.of(
-      "type", "hadoop",
       "default-namespace", "default",
       "parquet-enabled", "true",
       "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
@@ -61,7 +55,7 @@ public enum SparkCatalogConfig {
     return implementation;
   }
 
-  public Map<String, String> config() {
+  public Map<String, String> properties() {
     return config;
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
@@ -19,91 +19,41 @@
 
 package org.apache.iceberg.spark;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Map;
-import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.catalog.SupportsNamespaces;
-import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.hadoop.HadoopCatalog;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public abstract class SparkCatalogTestBase extends SparkTestBase {
-  private static File warehouse = null;
+public abstract class SparkCatalogTestBase extends SparkTestBaseWithCatalog {
 
-  @BeforeClass
-  public static void createWarehouse() throws IOException {
-    SparkCatalogTestBase.warehouse = File.createTempFile("warehouse", null);
-    Assert.assertTrue(warehouse.delete());
-  }
-
-  @AfterClass
-  public static void dropWarehouse() {
-    if (warehouse != null && warehouse.exists()) {
-      warehouse.delete();
-    }
-  }
-
+  // these parameters are broken out to avoid changes that need to modify lots of test suites
   @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
-    return new Object[][] {
-        { "testhive", SparkCatalog.class.getName(),
-          ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default"
-         ) },
-        { "testhadoop", SparkCatalog.class.getName(),
-          ImmutableMap.of(
-            "type", "hadoop"
-        ) },
-        { "spark_catalog", SparkSessionCatalog.class.getName(),
-          ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default",
-            "parquet-enabled", "true",
-            "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
-        ) }
-    };
+    return new Object[][] { {
+      SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.properties()
+    }, {
+      SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties()
+    }, {
+      SparkCatalogConfig.SPARK.catalogName(),
+        SparkCatalogConfig.SPARK.implementation(),
+        SparkCatalogConfig.SPARK.properties()
+    } };
   }
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
-  protected final String catalogName;
-  protected final Catalog validationCatalog;
-  protected final SupportsNamespaces validationNamespaceCatalog;
-  protected final TableIdentifier tableIdent = TableIdentifier.of(Namespace.of("default"), "table");
-  protected final String tableName;
-
-  public SparkCatalogTestBase(String catalogName, String implementation, Map<String, String> config) {
-    this.catalogName = catalogName;
-    this.validationCatalog = catalogName.equals("testhadoop") ?
-        new HadoopCatalog(spark.sessionState().newHadoopConf(), "file:" + warehouse) :
-        catalog;
-    this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
-
-    spark.conf().set("spark.sql.catalog." + catalogName, implementation);
-    config.forEach((key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
-
-    if (config.get("type").equalsIgnoreCase("hadoop")) {
-      spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
-    }
-
-    this.tableName = (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
-
-    sql("CREATE NAMESPACE IF NOT EXISTS default");
+  public SparkCatalogTestBase(SparkCatalogConfig config) {
+    super(config);
   }
 
-  protected String tableName(String name) {
-    return (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default." + name;
+  public SparkCatalogTestBase(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestRuntimeFiltering.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestRuntimeFiltering.java
@@ -31,8 +31,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.SparkCatalogConfig;
-import org.apache.iceberg.spark.SparkSpecifyCatalogTestBase;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -44,11 +43,7 @@ import org.junit.Test;
 import static org.apache.spark.sql.functions.date_add;
 import static org.apache.spark.sql.functions.expr;
 
-public class TestRuntimeFiltering extends SparkSpecifyCatalogTestBase {
-
-  public TestRuntimeFiltering() {
-    super(SparkCatalogConfig.SPARK_CATALOG_HADOOP);
-  }
+public class TestRuntimeFiltering extends SparkTestBaseWithCatalog {
 
   @After
   public void removeTables() {


### PR DESCRIPTION
This updates https://github.com/apache/iceberg/pull/3549 to use the new `SparkCatalogConfig` in both the new `SparkTestBaseWithCatalog` and existing `SparkCatalogTestBase`. I think it's slightly cleaner and uses the setup code from `SparkCatalogTestBase` since it didn't need to be modified.